### PR TITLE
Update ddnspod.sh

### DIFF
--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -66,7 +66,7 @@ case $(uname) in
 		
 		# 因为一般ipv6没有nat ipv6的获得可以本机获得
 		#ifconfig $(nvram get wan0_ifname_t) | awk '/Global/{print $3}' | awk -F/ '{print $1}' 
-		ip addr show dev eth0 | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\1/;t;d' #如果没有nvram，使用这条，注意将eth0改为本机上的网口设备 （通过 ifconfig 查看网络接口）
+		ip addr show dev eth0 | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\1/;t;d' | awk 'NR==1' #如果没有nvram，使用这条，注意将eth0改为本机上的网口设备 （通过 ifconfig 查看网络接口）
 		;;
  	esac
  


### PR DESCRIPTION
有的路由器分配ipv6地址时可能会分配两个，这时这里会获取到两行，一般第一行是长期地址，第二个是临时地址，所以应该默认选择第一行